### PR TITLE
Fix circular dependency

### DIFF
--- a/src/main/java/dott/subscription/channel/dto/ChannelResponseDto.java
+++ b/src/main/java/dott/subscription/channel/dto/ChannelResponseDto.java
@@ -2,16 +2,18 @@ package dott.subscription.channel.dto;
 
 import dott.subscription.constant.ChannelType;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @ToString
 public class ChannelResponseDto {
     private long id;
     private String name;
     private ChannelType channelType;
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 }

--- a/src/main/java/dott/subscription/channel/entity/Channel.java
+++ b/src/main/java/dott/subscription/channel/entity/Channel.java
@@ -29,9 +29,11 @@ public class Channel extends Auditable {
     private ChannelType channelType;
 
     @OneToMany(mappedBy = "channel")
+    @ToString.Exclude
     private List<Subscription> subscriptions;
 
     @OneToMany(mappedBy = "channel")
+    @ToString.Exclude
     private List<SubscriptionHistory> subscriptionHistories;
 
 }

--- a/src/main/java/dott/subscription/channel/service/ChannelService.java
+++ b/src/main/java/dott/subscription/channel/service/ChannelService.java
@@ -63,14 +63,12 @@ public class ChannelService {
     }
 
     // 채널 이름으로 채널 조회
-    public Channel isChannelNameDuplicated(String name) {
+    public void isChannelNameDuplicated(String name) {
         Optional<Channel> optionalChannel = channelRepository.findByName(name);
 
         if (optionalChannel.isPresent()) {
             // 채널이 존재할 경우
             throw new BusinessLogicException(Exceptions.CHANNEL_EXIST);
-        } else {
-            return optionalChannel.get();
         }
     }
 }

--- a/src/main/java/dott/subscription/member/entity/Member.java
+++ b/src/main/java/dott/subscription/member/entity/Member.java
@@ -24,6 +24,7 @@ public class Member extends Auditable {
     @Setter
     private String phoneNumber;
 
+    @ToString.Exclude
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Subscription subscription;
 

--- a/src/main/java/dott/subscription/subscription/dto/SubscribeResponseDto.java
+++ b/src/main/java/dott/subscription/subscription/dto/SubscribeResponseDto.java
@@ -10,10 +10,6 @@ import java.time.LocalDateTime;
 @Builder
 @ToString
 public class SubscribeResponseDto {
-    private String phoneNumber;
-    private long channelId;
-    private String channelName;
-    private SubscriptionStatus subscriptionStatus;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 }

--- a/src/main/java/dott/subscription/subscription/entity/Subscription.java
+++ b/src/main/java/dott/subscription/subscription/entity/Subscription.java
@@ -21,6 +21,7 @@ public class Subscription extends Auditable {
 
     @OneToOne
     @JoinColumn(name = "member_id", nullable = false, unique = true)
+    @ToString.Exclude
     private Member member;
 
     @Enumerated(EnumType.STRING)
@@ -29,6 +30,7 @@ public class Subscription extends Auditable {
 
     @ManyToOne
     @JoinColumn(name = "channel_id")
+    @ToString.Exclude
     private Channel channel;
 
     public Subscription(Member member, SubscriptionStatus subscriptionStatus) {

--- a/src/main/java/dott/subscription/subscription/mapper/SubscriptionMapper.java
+++ b/src/main/java/dott/subscription/subscription/mapper/SubscriptionMapper.java
@@ -5,16 +5,9 @@ import dott.subscription.subscription.entity.Subscription;
 import org.mapstruct.Mapper;
 
 
+
 @Mapper(componentModel = "spring")
 public interface SubscriptionMapper {
-    default SubscribeResponseDto subscriptionToSubscribeResponseDto(Subscription subscription){
+    SubscribeResponseDto subscriptionToSubscribeResponseDto(Subscription subscription);
 
-        return SubscribeResponseDto.builder()
-                .phoneNumber(subscription.getMember().getPhoneNumber())
-                .channelId(subscription.getChannel().getId())
-                .channelName(subscription.getChannel().getName())
-                .createdAt(subscription.getCreatedAt())
-                .modifiedAt(subscription.getModifiedAt())
-                .build();
-    }
 }

--- a/src/main/java/dott/subscription/subscription/service/SubscriptionService.java
+++ b/src/main/java/dott/subscription/subscription/service/SubscriptionService.java
@@ -64,6 +64,8 @@ public class SubscriptionService {
 
         // 구독 정보 최신화
         subscription.setSubscriptionStatus(subscribeDto.getSubscriptionStatus());
+        subscription.setMember(member);
+        subscription.setChannel(channel);
         subscriptionRepository.save(subscription);
 
         // 구독 이력 생성
@@ -118,6 +120,7 @@ public class SubscriptionService {
     // 외부 API 호출
     private boolean callExternalApi() {
         ResponseEntity<JsonNode> response = restTemplate.exchange(RANDOM_API_URL, HttpMethod.GET, null, JsonNode.class);
+        log.debug("EXTERNAL API RESPONSE : {}", response.toString());
         return response.getBody().get(0).get("random").asInt() == 1;
     }
 

--- a/src/main/java/dott/subscription/subscriptionHistory/entity/SubscriptionHistory.java
+++ b/src/main/java/dott/subscription/subscriptionHistory/entity/SubscriptionHistory.java
@@ -1,5 +1,6 @@
 package dott.subscription.subscriptionHistory.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import dott.subscription.audit.Auditable;
 import dott.subscription.channel.entity.Channel;
 import dott.subscription.constant.SubscriptionStatus;
@@ -28,10 +29,12 @@ public class SubscriptionHistory extends Auditable {
     @Column(nullable = false)
     private String channelName;
 
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "channel_id", nullable = false)
     private Channel channel;


### PR DESCRIPTION
### 순환참조 해결
- ToString 메서드에서 순환참조 발생
- 연관관계를 로그에 남기지 않아도 되므로 ToString.Exclude로 해결

### 구독 & 구독해지 응답 변경
- 구독 & 구독 해지 성공시 시간 이력만 남기도록 수정

### 채널 이름 중복 조회 메서드 리턴값 제거
- 중복 검증만 하도록 수정

### 채널 responseDto 필드명 오탈자 수정